### PR TITLE
1.1.0-sdk33 release branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ captures
 build
 build-cache
 generated
+bin
 
 # Mkdocs files
 docs/1.x

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 
     // Normally you would declare a version here, but we use dependency substitution in
     // settings.gradle to use the version built from inside the repo.
-    classpath 'app.cash.paparazzi:paparazzi-gradle-plugin'
+    classpath 'dev.chrisbanes.paparazzi:paparazzi-gradle-plugin'
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ bytebuddy-agent = { module = "net.bytebuddy:byte-buddy-agent", version.ref = "by
 bytebuddy-core = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "composeCompiler" }
-composeUi-material = { module = "androidx.compose.material:material", version = "1.2.1" }
+composeUi-material = { module = "androidx.compose.material:material", version = "1.3.0-rc01" }
 
 guava = { module = "com.google.guava:guava", version = "31.0.1-jre" }
 

--- a/paparazzi/gradle.properties
+++ b/paparazzi/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=dev.chrisbanes.paparazzi
-VERSION_NAME=1.1.0-sdk33-alpha01
+VERSION_NAME=1.1.0-sdk33-alpha02
 
 POM_URL=https://github.com/chrisbanes/paparazzi/
 POM_SCM_URL=https://github.com/chrisbanes/paparazzi/

--- a/paparazzi/gradle.properties
+++ b/paparazzi/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=dev.chrisbanes.paparazzi
-VERSION_NAME=1.1.0-sdk33-alpha02
+VERSION_NAME=1.1.0-sdk33-alpha03
 
 POM_URL=https://github.com/chrisbanes/paparazzi/
 POM_SCM_URL=https://github.com/chrisbanes/paparazzi/

--- a/paparazzi/gradle.properties
+++ b/paparazzi/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=dev.chrisbanes.paparazzi
-VERSION_NAME=1.1.0-SNAPSHOT
+VERSION_NAME=1.1.0-sdk33-alpha01
 
 POM_URL=https://github.com/chrisbanes/paparazzi/
 POM_SCM_URL=https://github.com/chrisbanes/paparazzi/

--- a/paparazzi/gradle.properties
+++ b/paparazzi/gradle.properties
@@ -1,18 +1,18 @@
-GROUP=app.cash.paparazzi
+GROUP=dev.chrisbanes.paparazzi
 VERSION_NAME=1.1.0-SNAPSHOT
 
-POM_URL=https://github.com/cashapp/paparazzi/
-POM_SCM_URL=https://github.com/cashapp/paparazzi/
-POM_SCM_CONNECTION=scm:git:git://github.com/cashapp/paparazzi.git
-POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/cashapp/paparazzi.git
+POM_URL=https://github.com/chrisbanes/paparazzi/
+POM_SCM_URL=https://github.com/chrisbanes/paparazzi/
+POM_SCM_CONNECTION=scm:git:git://github.com/chrisbanes/paparazzi.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/chrisbanes/paparazzi.git
 
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENCE_DIST=repo
 
-POM_DEVELOPER_ID=cashapp
-POM_DEVELOPER_NAME=CashApp
-POM_DEVELOPER_URL=https://github.com/cashapp/
+POM_DEVELOPER_ID=chrisbanes
+POM_DEVELOPER_NAME=Chris Banes
+POM_DEVELOPER_URL=https://github.com/chrisbanes/
 
 SONATYPE_HOST=DEFAULT
 RELEASE_SIGNING_ENABLED=true

--- a/paparazzi/gradle.properties
+++ b/paparazzi/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=dev.chrisbanes.paparazzi
-VERSION_NAME=1.1.0-sdk33-alpha03
+VERSION_NAME=1.1.0-sdk33-alpha04
 
 POM_URL=https://github.com/chrisbanes/paparazzi/
 POM_SCM_URL=https://github.com/chrisbanes/paparazzi/

--- a/paparazzi/paparazzi-gradle-plugin/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'com.vanniktech.maven.publish'
 gradlePlugin {
   plugins {
     paparazzi {
-      id = 'app.cash.paparazzi'
+      id = 'dev.chrisbanes.paparazzi'
       implementationClass = 'app.cash.paparazzi.gradle.PaparazziPlugin'
     }
   }

--- a/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/java/app/cash/paparazzi/gradle/PaparazziPlugin.kt
@@ -234,7 +234,7 @@ class PaparazziPlugin : Plugin<Project> {
 
   private fun Project.addTestDependency() {
     configurations.getByName("testImplementation").dependencies.add(
-      dependencies.create("app.cash.paparazzi:paparazzi:$VERSION")
+      dependencies.create("dev.chrisbanes.paparazzi:paparazzi:$VERSION")
     )
   }
 

--- a/paparazzi/paparazzi-gradle-plugin/src/main/resources/META-INF/gradle-plugins/app.cash.paparazzi.properties
+++ b/paparazzi/paparazzi-gradle-plugin/src/main/resources/META-INF/gradle-plugins/app.cash.paparazzi.properties
@@ -1,0 +1,1 @@
+implementation-class=app.cash.paparazzi.gradle.PaparazziPlugin

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/appcompat-missing/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/appcompat-missing/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/appcompat-present/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/appcompat-present/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/cacheable/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/cacheable/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-dispatcher/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-dispatcher/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-wear/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose-wear/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/compose/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/configuration-cache/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/configuration-cache/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/custom-fonts-code/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/custom-fonts-code/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/custom-fonts-xml/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/custom-fonts-xml/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/declare-android-plugin-after/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/declare-android-plugin-after/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
   id 'com.android.library' // intentionally declared after paparazzi plugin
 }
 

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/different-target-sdk/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/different-target-sdk/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'com.android.library'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/edit-mode-intercept/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/edit-mode-intercept/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/exclude-androidtest/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/exclude-androidtest/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'com.android.library'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-off/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-off/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-on/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/flag-debug-linked-objects-on/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/imm-soft-input/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/imm-soft-input/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/invalid-application-plugin/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/invalid-application-plugin/build.gradle
@@ -1,4 +1,4 @@
 plugins {
   id 'com.android.application'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/layout-direction/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/layout-direction/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/locale-qualifier/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/locale-qualifier/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/material-components-present/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/material-components-present/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/missing-library-plugin/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/missing-library-plugin/build.gradle
@@ -1,3 +1,3 @@
 plugins {
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/missing-platform-dir/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/missing-platform-dir/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-with-android/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-with-android/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'org.jetbrains.kotlin.multiplatform'
   id 'com.android.library'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 kotlin {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-without-android/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/multiplatform-plugin-without-android/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'org.jetbrains.kotlin.multiplatform'
   id 'com.android.library'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/night-mode-compose/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/night-mode-compose/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/night-mode-xml/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/night-mode-xml/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/nine-patch/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/nine-patch/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources-no-deps/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources-no-deps/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources/module/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/non-transitive-resources/module/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/open-assets/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/open-assets/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'com.android.library'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/open-transitive-assets/consumer/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/open-transitive-assets/consumer/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/prefer-dsl-namespace/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/prefer-dsl-namespace/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'com.android.library'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-modules/module/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-modules/module/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-tests/module/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/record-mode-multiple-tests/module/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/record-mode/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/record-mode/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-asset-change/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-asset-change/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-report/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-report/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-resource-change/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-resource-change/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-snapshots/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/rerun-snapshots/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/text-appearances-code/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/text-appearances-code/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/text-appearances-xml/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/text-appearances-xml/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/update-paparazzi-config/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/update-paparazzi-config/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-aapt-code/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-aapt-code/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-aapt-compose/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-aapt-compose/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-aapt-xml/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-aapt-xml/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure-multiple-modules/module/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure-multiple-modules/module/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-mode-failure/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-mode-success-multiple-modules/module/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-mode-success-multiple-modules/module/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-mode-success/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-mode-success/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-rendering-modes/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-rendering-modes/build.gradle
@@ -1,7 +1,7 @@
 plugins  {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-resources-java/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'com.android.library'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-resources-kotlin/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-snapshot/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-snapshot/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-svgs/build.gradle
+++ b/paparazzi/paparazzi-gradle-plugin/src/test/projects/verify-svgs/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.android.library'
   id 'kotlin-android'
-  id 'app.cash.paparazzi'
+  id 'dev.chrisbanes.paparazzi'
 }
 
 repositories {

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -575,7 +575,7 @@ class Paparazzi @JvmOverloads constructor(
       val snapshotInvalidations = recomposer.javaClass
         .getDeclaredField("snapshotInvalidations")
         .apply { isAccessible = true }
-        .get(recomposer) as MutableList<*>
+        .get(recomposer) as MutableCollection<*>
       compositionInvalidations.clear()
       snapshotInvalidations.clear()
       applyObservers.clear()

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -144,7 +144,12 @@ class Paparazzi @JvmOverloads constructor(
   }
 
   fun prepare(description: Description) {
-    forcePlatformSdkVersion(environment.compileSdkVersion)
+    if (environment.compileSdkVersion > 32) {
+      // The version of layout we're using only works up to SDK level 32, so we need to coerce
+      // the compileSdkVersion down to 32
+      forceBuildVersionProp("SDK_INT", 32)
+      forceBuildVersionProp("CODENAME", "Sv2")
+    }
 
     val layoutlibCallback =
       PaparazziCallback(logger, environment.packageName, environment.resourcePackageNames)
@@ -396,7 +401,7 @@ class Paparazzi @JvmOverloads constructor(
     return TestName(packageName, className, methodName)
   }
 
-  private fun forcePlatformSdkVersion(compileSdkVersion: Int) {
+  private fun forceBuildVersionProp(name: String, value: Any) {
     val buildVersionClass = try {
       Paparazzi::class.java.classLoader.loadClass("android.os.Build\$VERSION")
     } catch (e: ClassNotFoundException) {
@@ -404,8 +409,8 @@ class Paparazzi @JvmOverloads constructor(
       return
     }
     buildVersionClass
-      .getFieldReflectively("SDK_INT")
-      .setStaticValue(compileSdkVersion)
+      .getFieldReflectively(name)
+      .setStaticValue(value)
   }
 
   private fun initializeAppCompatIfPresent() {

--- a/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -149,6 +149,9 @@ class Paparazzi @JvmOverloads constructor(
       // the compileSdkVersion down to 32
       forceBuildVersionProp("SDK_INT", 32)
       forceBuildVersionProp("CODENAME", "Sv2")
+    } else {
+      // Otherwise we just pass through the compile sdk
+      forceBuildVersionProp("SDK_INT", environment.compileSdkVersion)
     }
 
     val layoutlibCallback =

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
-apply plugin: 'app.cash.paparazzi'
+apply plugin: 'dev.chrisbanes.paparazzi'
 
 android {
   // We test against compile Sdk 33, to verify that the pinning behavior

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -3,7 +3,9 @@ apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'app.cash.paparazzi'
 
 android {
-  compileSdk libs.versions.compileSdk.get() as int
+  // We test against compile Sdk 33, to verify that the pinning behavior
+  // works
+  compileSdk 33
   defaultConfig {
     minSdk libs.versions.minSdk.get() as int
   }

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,9 +4,9 @@ include ':sample'
 
 includeBuild('paparazzi') {
   dependencySubstitution {
-    substitute module('app.cash.paparazzi:paparazzi') using project(':paparazzi')
-    substitute module('app.cash.paparazzi:paparazzi-agent') using project(':paparazzi-agent')
-    substitute module('app.cash.paparazzi:paparazzi-gradle-plugin') using project(':paparazzi-gradle-plugin')
+    substitute module('dev.chrisbanes.paparazzi:paparazzi') using project(':paparazzi')
+    substitute module('dev.chrisbanes.paparazzi:paparazzi-agent') using project(':paparazzi-agent')
+    substitute module('dev.chrisbanes.paparazzi:paparazzi-gradle-plugin') using project(':paparazzi-gradle-plugin')
   }
 }
 


### PR DESCRIPTION
I've opened this PR to document history for the `dev.chrisbanes.paparazzi:paparazzi:1.1.0-sdk33-FOO` released artifacts. This branch is based on the top-of-tree of the master branch of [cashapp/paparazzi](https://github.com/cashapp/paparazzi) (currently commit https://github.com/cashapp/paparazzi/commit/24b11b528d0cfcedb6bd1d3c5e43176127bd1f09), with the necessary fixes to unblock teams which need to use a `compileSdkVersion` of 33. Primarily, that is a cherry-pick of the fix from https://github.com/cashapp/paparazzi/pull/605.

I have tested this fork on the Twitter for Android codebase, and successfully ran our Paparazzi tests using Compose UI `1.3.0-rc01` (which is requires to be built against SDK 33).

## Future of this fork

To be very clear here, the artifacts that I have published below are published without any guarantees, or commitment to support. I am only publishing these to unblock teams _right now_. I have not modified the package name, or anything like that, to re-enforce that this is a short-term fork of the [CashApp](https://github.com/cashapp) team's great work. 

The work to upgrade layoutlib in Paparazzi is already tracked in https://github.com/cashapp/paparazzi/issues/604, which will mean native SDK 33 support. Once that is fixed (and released), this fork will no longer be necessary, and people can swap their dependencies back.

Any unrelated bugs should be directed to the upstream [cashapp/paparazzi](https://github.com/cashapp/paparazzi) repository.

## Artifacts

To use these artifacts, you can change your dependency to the following:

Using plugin application:

```groovy
buildscript {
  repositories {
    mavenCentral()
    google()
  }
  dependencies {
    classpath 'dev.chrisbanes.paparazzi:paparazzi-gradle-plugin:1.1.0-sdk33-alpha04'
  }
}

apply plugin: 'dev.chrisbanes.paparazzi'

// the follow also works instead (for easy migration)
// apply plugin: 'app.cash.paparazzi'
```

Using the plugins DSL:
```groovy
plugins {
  id 'dev.chrisbanes.paparazzi' version '1.1.0-sdk33-alpha04'
}
```

https://central.sonatype.dev/artifact/dev.chrisbanes.paparazzi/paparazzi/1.1.0-sdk33-alpha03